### PR TITLE
Add auto build with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    
+    - name: Build
+      shell: cmd
+      run: "\"C:/Program Files (x86)/Inno Setup 6/ISCC.exe\" LI-Alternate-Installer.iss"
+    
+    - name: Upload a Build Artifact
+      uses: actions/upload-artifact@v2.2.1
+      with:
+        path: 
+          "bin/LEGO Island Alternate Installer 1.1.0.exe"

--- a/LI-Alternate-Installer.iss
+++ b/LI-Alternate-Installer.iss
@@ -1,5 +1,5 @@
-; LEGO Island Alternate Installer
-; Created 2012-2014 Triangle717
+﻿; LEGO Island Alternate Installer
+; Created 2012-2020 Triangle717
 ; <http://Triangle717.WordPress.com/>
 ; Contains source code from Grim Fandango Setup
 ; Copyright (c) 2007-2008 Bgbennyboy
@@ -63,8 +63,7 @@ Name: "English"; MessagesFile: "compiler:Default.isl"
 
 [Messages]
 English.BeveledLabel={#MyAppInstallerName}
-; WelcomeLabel2 is overridden because I'm unsure if every LEGO Island
-; disc says version 1.1.0.0 or just mine.
+; WelcomeLabel2 is overridden because of differing versions of LEGO Island.
 English.WelcomeLabel2=This will install [name] on your computer.%n%nIt is recommended that you close all other applications before continuing.
 ; DiskSpaceMBLabel is overridden because it reports an incorrect installation size.
 English.DiskSpaceMBLabel=


### PR DESCRIPTION
The binary for the installer on the Releases page is very outdated now (the latest release being version 1.0.0, while master builds 1.1.0). As a result, I propose this PR to set up auto building with GitHub Actions to make keeping things current a bit easier. Of course, it is entirely up to you if you'd like to adopt this change, but I thought I'd throw this idea out there.

The Alternate Installer is used by most people now as their primary method of installing the game, especially with new discoveries, such as the installer on the Japanese version of the game's disc purposefully refusing to run on any computer that is not running Windows 95. However, 99% of people will just use what is on the Releases page. Personally, I think it would be ideal if this were set up to automatically upload the binary to the Releases page, similar to how is done with [LEGOIslandRebuilder](https://github.com/itsmattkc/LEGOIslandRebuilder). (but that specific functionality is beyond my control.)

Let me know what you think of this idea!
