### PR TITLE
Automatically upload build to releases page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TRAVIS_REPO_SLUG: le717/Island-Alternate-Installer
+        TRAVIS_COMMIT: ${{ github.sha }}
       run: |
         curl -fLOSs --retry 2 --retry-delay 60 https://github.com/probonopd/uploadtool/raw/master/upload.sh
         ./upload.sh "bin/LEGO Island Alternate Installer 1.1.0.exe"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,13 @@ jobs:
       with:
         path: 
           "bin/LEGO Island Alternate Installer 1.1.0.exe"
+
+    - name: Upload to Releases
+      shell: bash
+      if: github.event_name == 'push'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TRAVIS_REPO_SLUG: le717/Island-Alternate-Installer
+      run: |
+        curl -fLOSs --retry 2 --retry-delay 60 https://github.com/probonopd/uploadtool/raw/master/upload.sh
+        ./upload.sh "bin/LEGO Island Alternate Installer 1.1.0.exe"


### PR DESCRIPTION
Enhancement on top of PR #2.

With the way this script is set up, you will also be able to test compiled binaries of PRs (from the artifacts on the build status page) as well. But as always, only commits to master get pushed to the Releases page.