### PR TITLE
Fix uploadtool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,5 @@ jobs:
         TRAVIS_REPO_SLUG: le717/Island-Alternate-Installer
         TRAVIS_COMMIT: ${{ github.sha }}
       run: |
-        curl -fLOSs --retry 2 --retry-delay 60 https://github.com/probonopd/uploadtool/raw/master/upload.sh
+        curl -fLOSs --retry 2 --retry-delay 60 https://raw.githubusercontent.com/itsmattkc/uploadtool/master/upload.sh
         ./upload.sh "bin/LEGO Island Alternate Installer 1.1.0.exe"


### PR DESCRIPTION
Sorry for yet another PR on building, however I noticed that the uploadtool script, which is responsible for uploading the built binaries to the Releases page, has a bug where it fails on directories that use spaces. This PR provides a version of the script which corrects that bug, and will let the auto-upload work correctly.